### PR TITLE
Wrap errors instead of formatting

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -279,7 +279,7 @@ func (chat *Chat) UnmarshalJSON(data []byte) error {
 		Alias: (*Alias)(chat),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return fmt.Errorf("failed to unmarshal chat: %v", err)
+		return fmt.Errorf("failed to unmarshal chat: %w", err)
 	}
 	return nil
 }

--- a/storage.go
+++ b/storage.go
@@ -26,12 +26,12 @@ func (chat *Chat) Load(ctx context.Context, key string) error {
 
 	reader, err := chat.Options.S3.Get(ctx, key)
 	if err != nil {
-		return fmt.Errorf("failed to get session from storage: %v", err)
+		return fmt.Errorf("failed to get session from storage: %w", err)
 	}
 	defer reader.Close()
 
 	if err := json.NewDecoder(reader).Decode(chat); err != nil {
-		return fmt.Errorf("failed to decode chat data: %v", err)
+		return fmt.Errorf("failed to decode chat data: %w", err)
 	}
 
 	return nil
@@ -45,7 +45,7 @@ func (chat *Chat) Save(ctx context.Context, key string) error {
 
 	data, err := json.Marshal(chat)
 	if err != nil {
-		return fmt.Errorf("failed to marshal chat data: %v", err)
+		return fmt.Errorf("failed to marshal chat data: %w", err)
 	}
 
 	return chat.Options.S3.Put(ctx, key, bytes.NewReader(data))

--- a/tool_calls.go
+++ b/tool_calls.go
@@ -67,7 +67,7 @@ func (tcc *ToolCallContext) Arguments() (map[string]any, error) {
 func (tcc *ToolCallContext) Return(result map[string]any) error {
 	jsonData, err := json.Marshal(result)
 	if err != nil {
-		return fmt.Errorf("failed to marshal result: %v", err)
+		return fmt.Errorf("failed to marshal result: %w", err)
 	}
 	tcc.Chat.AddToolContent(tcc.Name(), tcc.ToolCall.ID, string(jsonData))
 	return nil

--- a/tools.go
+++ b/tools.go
@@ -44,7 +44,7 @@ func (f *Function) ArgumentsMap() (map[string]interface{}, error) {
 
 	var result map[string]interface{}
 	if err := json.Unmarshal([]byte(f.Arguments), &result); err != nil {
-		return nil, fmt.Errorf("failed to parse arguments: %v", err)
+		return nil, fmt.Errorf("failed to parse arguments: %w", err)
 	}
 	return result, nil
 }


### PR DESCRIPTION
Useful in cases when we want to check against the underlying error.

E.g., allows idiomatic error check S3 NoSuchKey:

```
	// Load or create chat
	chat, err := m.storage.Load(ctx, chatID)
	if err != nil {
		var NoSuchKeyError *types.NoSuchKey
		if !errors.As(err, &NoSuchKeyError) {
			return "", fmt.Errorf("error loading chat: %w", err)
		}
	}

	// Good to use chat
```

instead of 

```
	// Load or create chat
	chat, err := m.storage.Load(ctx, chatID)
	if err != nil {
		if !strings.Contains(err.Error(), "No Such Key") {
			return "", fmt.Errorf("error loading chat: %w", err)
		}
	}

	// Good to use chat
```